### PR TITLE
Stop iterating after passing outlier threshold

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -352,8 +352,11 @@ def get_outliers_single(db: DuckDBPyConnection,
         if row['frac'] <= fraction_for_outlier and ((use_zscore and zscores[0] <= 2) or not use_zscore):
             outliers = []
         else:
-            outliers = [(column_type(row[column]), round(row['frac'], 3)) for index, row in df_all.iterrows()
-                        if row['frac'] > fraction_for_outlier or (use_zscore and zscores[index] > 2)]
+            for index, row in df_all.iterrows():
+                if row['frac'] > fraction_for_outlier or (use_zscore and zscores[index] > 2):
+                    outliers.append((column_type(row[column]), round(row['frac'], 3)))
+                else:
+                    break
 
         if outliers and return_others and (explained := sum([fraction for _, fraction in outliers])) < 0.99:
             outliers.append(('others', round(1 - explained, 3)))


### PR DESCRIPTION
Determining attack target can take a very long time if there are large numbers of different destination addresses in a pcap  (as in stressthem/tcp-syn.pcap). This is caused by the function for determining outliers (util.py/get_outliers_single), which iterates over *all* entries returned by the query, even if the iteration has already moved passed the threshold. 

With tcp-syn.pcap this amounts to over 6 million iterations, taking minutes (needlessly, as the results are ordered by fraction in a descending order).

By stopping when the iteration has passed the threshold, this is reduced to a mere second or two.
